### PR TITLE
Adding "about" dialog box to the website

### DIFF
--- a/src/app/about4dvd.component.html
+++ b/src/app/about4dvd.component.html
@@ -51,7 +51,7 @@
     </p>
 
     <p>
-      While DVD plays movies and music, 4DVD (<a href="www.4dvd.org"
+      While DVD plays movies and music, 4DVD (<a href="http://www.4dvd.org"
         >www.4dvd.org</a
       >) is a website technology that plays big data. The 4DVD technology was
       originally developed as part of Dr. Julien Pierret’s PhD research during

--- a/src/app/about4dvd.component.html
+++ b/src/app/about4dvd.component.html
@@ -1,0 +1,124 @@
+<div id="About4dvd">
+  <h2 mat-dialog-title>About 4DVD</h2>
+  <mat-dialog-content>
+    <p>
+      Everyone talks about global warming or climate change, but few have
+      actually seen or obtained the climate data, because accessing climate data
+      is a technically challenging task. 4DVD enables anyone to access climate
+      data immediately as long as the person can navigate a website.
+    </p>
+
+    <p>
+      4DVD is acronym of 4-Dimensional Visual Delivery of Big Climate Data, is a
+      unique software developed at the Climate Informatics Lab, San Diego State
+      University for the instant delivery of big climate data to classrooms and
+      households around the world in a convenient visual way. It is like an
+      Amazon audio book shopping experience. In fact, the 4DVD technology is
+      currently partnering with Amazon and uses Amazon cloud server to store and
+      deliver the climate data.
+    </p>
+
+    <p>
+      4DVD makes the climate data acquisition in the same way as one shops on
+      Amazon for digital products, such as digital books or movies. Therefore,
+      the 4DVD technology can help make the climate data be delivered instantly
+      to classrooms, museums and households.
+    </p>
+
+    <p>
+      Downloading the massive amount of data, making analysis on them, or
+      requesting a server to produce a figure are among the conventional
+      practices of data acquisition in the climate research community. This
+      passive approach is slow and requires climate expertise or professional
+      data analysis training. The powerful 4DVD technology have changed this and
+      enabled an active data acquisition in both visual and digital forms, as if
+      the data are delivered to a user. Any person who is able to shop on Amazon
+      can acquire climate data from 4DVD.
+    </p>
+
+    <p>
+      This convenient climate data technology is achieved because the 4DVD big
+      data technology optimizes the resources from database, data server, and
+      the computer browser of a client. A client does not need to download an
+      entire dataset, such as 5 gigabytes data from a climate modeling, and then
+      to make analysis of a desired case. Instead, users run the 4DVD code on
+      their own computer browsers to visually obtain the desired data from the
+      optimal routes of database and data server, instantly see the data as a
+      figure, a spatial map or a time series, and quickly determine whether this
+      is the desired climate scenario of interest. Eventually, the user can
+      choose to download the digital data for further analysis or figure
+      re-plotting.
+    </p>
+
+    <p>
+      While DVD plays movies and music, 4DVD (<a href="www.4dvd.org"
+        >www.4dvd.org</a
+      >) is a website technology that plays big data. The 4DVD technology was
+      originally developed as part of Dr. Julien Pierret’s PhD research during
+      2012-2018, directed by Samuel Shen, Distinguished Professor of Mathematics
+      and Statistics, San Diego State University. A paper on the 4DVD technology
+      was first published in 2017 (Pierret and Shen 2017). Since then, many
+      students, researchers, and technical personnel have been contributing to
+      the further development of 4DVD, under the leadership of Drs. Pierret and
+      Shen.
+    </p>
+
+    <p>
+      The original database idea for the 4DVD was from Julien Pierret around
+      2010. Samuel Shen developed a framework of the climate data delivery
+      system and coined the term “4DVD” around 2012, when the 4DVD development
+      formally began. The beta-version was available in 2016 for demonstrations.
+      The first public demonstration was made at the NOAA National Environmental
+      Information, Asheville, North Carolina, in March 2016.
+    </p>
+
+    <p>
+      4DVD has been licensed as an open source code. To license 4DVD for your
+      commercial use, please contact the San Diego State University’s Technology
+      Transfer Office.
+    </p>
+    <p>
+      <i
+        >SDSU Research Foundation <br />
+        Gateway Center <br />
+        5250 Campanile Drive <br />
+        San Diego, CA 92182 <br />
+        Tel: 619-594-1900</i
+      >
+    </p>
+
+    <p>The standard academic citation for this work is:</p>
+    <p>
+      Pierret, J., and S.S.P. Shen, 2017: 4D visual delivery of big climate
+      data: A fast web database application system.<i>
+        Advances in Data Science and Adaptive Analysis</i
+      >, <b>9</b>, DOI: 10.1142/S2424922X17500061.
+    </p>
+
+    <p>
+      <b> Disclaimer: </b>This program is distributed in the hope that it will
+      be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    </p>
+
+    <p>
+      When downloading the 4DVD software, one should have received a copy of the
+      GNU General Public License along with this program; if not, write to the
+      Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+      02111-1307 USA
+    </p>
+    <p>
+      This project was generated with
+      <a href="https://github.com/angular/angular-cli">Angular CLI</a>
+      version 1.0.1.
+    </p>
+    <p>
+      One can redistribute it and/or modify 4DVD under the terms of the GNU
+      General Public License v3 as published by the Free Software Foundation. If
+      not stated otherwise, this applies to all files contained in the 4DVD
+      package and its sub-directories (with the exception of the "node_modules"
+      folder; the libraries used as part of the 4DVD may involve different
+      licenses.)
+    </p>
+  </mat-dialog-content>
+</div>

--- a/src/app/about4dvd.component.ts
+++ b/src/app/about4dvd.component.ts
@@ -1,0 +1,12 @@
+import { Component, Inject, OnInit, ViewEncapsulation } from "@angular/core";
+import { MAT_DIALOG_DATA, MatDialog } from "@angular/material";
+
+@Component({
+  templateUrl: "./about4dvd.component.html",
+  styleUrls: ["./about4dvd.component.css"]
+})
+export class About4dvdComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit() {}
+}

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,0 +1,6 @@
+.AboutButton {
+  margin-right: 20px;
+  margin-left: 20px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -15,10 +15,21 @@
     id="TabMenu"
     style="margin-bottom: 0px; z-index: 10;"
   >
-    <div class="col blue white-text">
+    <div class="col s6 blue white-text">
       <h5>{{ title }}</h5>
     </div>
-    <div id="" class="scol s11"></div>
+    <div id="QuickButtons" class="col s6" align="right">
+      <div class="AboutButton">
+        <button
+          mat-raised-button
+          (click)="OpenAboutDialog()"
+          matTooltip="About 4DVD"
+          matTooltipPosition="right"
+        >
+          <mat-icon>info</mat-icon> About
+        </button>
+      </div>
+    </div>
   </div>
 
   <!--div #ClimateSystem id="ClimateSystem" style="width:100%; overflow:hidden; z-index: 2; margin-bottom: 0px;" class="row">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,6 +2,7 @@ import {
   Component,
   ElementRef,
   HostListener,
+  Inject,
   Input,
   OnInit,
   ViewChild
@@ -9,6 +10,9 @@ import {
 
 declare var jQuery: any;
 
+import { MAT_DIALOG_DATA, MatDialog } from "@angular/material";
+import { About4dvdComponent } from "./about4dvd.component";
+import { ColorMapMenuComponent } from "./color-map-menu.component";
 import { Controller } from "./controller";
 import { GetJson } from "./getJson";
 import { Model } from "./model";
@@ -19,12 +23,16 @@ import { Model } from "./model";
   styleUrls: ["./app.component.css"]
   // providers: [GetJson]
 })
-// tslint:disable:one-line
 export class AppComponent {
   private _getJson: GetJson;
   title = "4DVD (4-Dimensional Visual Delivery of Big Climate Data)";
 
-  constructor(getJson: GetJson) {
+  constructor(getJson: GetJson, public dialog: MatDialog) {
     this._getJson = getJson;
+  }
+
+  public OpenAboutDialog() {
+    const dialogRef = this.dialog.open(About4dvdComponent, {});
+    dialogRef.afterClosed().subscribe(() => {});
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -21,6 +21,7 @@ import {
 import { BrowserModule } from "@angular/platform-browser";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { NgxChartsModule } from "@swimlane/ngx-charts";
+import { About4dvdComponent } from "./about4dvd.component";
 import { AppComponent } from "./app.component";
 import { ColorMapMenuComponent } from "./color-map-menu.component";
 import { DatasetMenuComponent } from "./dataset-menu.component";
@@ -31,10 +32,11 @@ import { ViewComponent } from "./view.component";
 @NgModule({
   declarations: [
     AppComponent,
-    ViewComponent,
+    About4dvdComponent,
     ColorMapMenuComponent,
     DatasetMenuComponent,
-    TimeseriesMenuComponent
+    TimeseriesMenuComponent,
+    ViewComponent
   ],
   imports: [
     BrowserModule,
@@ -60,6 +62,7 @@ import { ViewComponent } from "./view.component";
   providers: [GetJson, { provide: APP_BASE_HREF, useValue: "/" }],
   bootstrap: [AppComponent],
   entryComponents: [
+    About4dvdComponent,
     ColorMapMenuComponent,
     DatasetMenuComponent,
     TimeseriesMenuComponent

--- a/src/app/timeseries-menu.component.ts
+++ b/src/app/timeseries-menu.component.ts
@@ -48,7 +48,7 @@ export class TimeseriesMenuComponent {
       "#cab2d6",
       "#6a3d9a",
       "#ffff99",
-      "#b15928]"
+      "#b15928"
     ]
   };
 


### PR DESCRIPTION
I took SI's PR: https://github.com/dafrenchyman/4dvd/pull/34, refactored it a bit and it part of the "top" bar. We can easily move it somewhere else when we get a logo.