### PR TITLE
ID - Time Series Menu Changes

### DIFF
--- a/src/app/settings.ts
+++ b/src/app/settings.ts
@@ -157,6 +157,7 @@ export class Settings {
   rGlobe: 0;
   lastTime: 0;
 
+  // TODO: Change "Default" in database with "Single Layer"
   levelCheck(str) {
     if (str === "Default") {
       return "Single Level";

--- a/src/app/settings.ts
+++ b/src/app/settings.ts
@@ -157,6 +157,14 @@ export class Settings {
   rGlobe: 0;
   lastTime: 0;
 
+  levelCheck(str) {
+    if (str === "Default") {
+      return "Single Level";
+    } else {
+      return str;
+    }
+  }
+
   // TODO: HACK: We should move this to the database. So the value just comes from a column so we don't need this function
   public GenerateTitle(str): string {
     // Title for main view.. returns in format: "DatasetName | Pressure Level"

--- a/src/app/timeseries-menu.component.css
+++ b/src/app/timeseries-menu.component.css
@@ -11,15 +11,33 @@ h2 {
 #graph_button {
   position: absolute;
   top: 13px;
+<<<<<<< HEAD
+<<<<<<< HEAD
   right: 40px;
+=======
+  right: 80px;
+>>>>>>> rebase
+=======
+  right: 40px;
+>>>>>>> rebase 2
 }
 @media print {
   * {
     -webkit-print-color-adjust: exact !important;
   }
+<<<<<<< HEAD
+<<<<<<< HEAD
   #graph_button,
   #Download_button,
   .closeBtn {
+=======
+  #graph_button,#Download_button,.closeBtn {
+>>>>>>> rebase
+=======
+  #graph_button,
+  #Download_button,
+  .closeBtn {
+>>>>>>> prettier/tslint
     display: none;
   }
   #TimeseriesPlot {
@@ -32,6 +50,8 @@ h2 {
 .closeBtn {
   position: absolute;
   top: 10px;
+<<<<<<< HEAD
+<<<<<<< HEAD
   right: 0;
   color: black;
   background-color: #ffffff;
@@ -40,4 +60,22 @@ h2 {
 .closeBtn:active,
 :after {
   background-color: #ffffff;
+=======
+  right: 30px;
+=======
+  right: 0;
+>>>>>>> rebase 2
+  color: black;
+  background-color: #ffffff;
+}
+
+<<<<<<< HEAD
+.closeBtn:active, :after {
+  background-color: #FFFFFF;
+>>>>>>> rebase
+=======
+.closeBtn:active,
+:after {
+  background-color: #ffffff;
+>>>>>>> prettier/tslint
 }

--- a/src/app/timeseries-menu.component.css
+++ b/src/app/timeseries-menu.component.css
@@ -17,7 +17,9 @@ h2 {
   * {
     -webkit-print-color-adjust: exact !important;
   }
-  #graph_button,#Download_button,.closeBtn {
+  #graph_button,
+  #Download_button,
+  .closeBtn {
     display: none;
   }
   #TimeseriesPlot {
@@ -32,9 +34,10 @@ h2 {
   top: 10px;
   right: 30px;
   color: black;
-  background-color: #FFFFFF;
+  background-color: #ffffff;
 }
 
-.closeBtn:active, :after {
-  background-color: #FFFFFF;
+.closeBtn:active,
+:after {
+  background-color: #ffffff;
 }

--- a/src/app/timeseries-menu.component.css
+++ b/src/app/timeseries-menu.component.css
@@ -11,7 +11,7 @@ h2 {
 #graph_button {
   position: absolute;
   top: 13px;
-  right: 80px;
+  right: 40px;
 }
 @media print {
   * {
@@ -32,7 +32,7 @@ h2 {
 .closeBtn {
   position: absolute;
   top: 10px;
-  right: 30px;
+  right: 0;
   color: black;
   background-color: #ffffff;
 }

--- a/src/app/timeseries-menu.component.css
+++ b/src/app/timeseries-menu.component.css
@@ -1,23 +1,40 @@
 #TimeseriesPlot {
+  position: relative;
+  overflow-x: hidden;
+  height: 100%;
+  width: 100%;
 }
 h2 {
   margin: 0;
   display: inline-block;
 }
 #graph_button {
-  float: right;
+  position: absolute;
+  top: 13px;
+  right: 80px;
 }
 @media print {
   * {
     -webkit-print-color-adjust: exact !important;
   }
-  #graph_button {
+  #graph_button,#Download_button,.closeBtn {
     display: none;
   }
-  #Download_button {
-    display: none;
+  #TimeseriesPlot {
+    width: auto;
   }
   @page {
     size: landscape;
   }
+}
+.closeBtn {
+  position: absolute;
+  top: 10px;
+  right: 30px;
+  color: black;
+  background-color: #FFFFFF;
+}
+
+.closeBtn:active, :after {
+  background-color: #FFFFFF;
 }

--- a/src/app/timeseries-menu.component.html
+++ b/src/app/timeseries-menu.component.html
@@ -11,7 +11,14 @@
       >
         Save Graph
       </button>
-      <button mat-icon-button (click)="this.closeTimeSeries()" class="closeBtn" matTooltip="Close Time Series Chart"><mat-icon>close</mat-icon></button>
+      <button
+        mat-icon-button
+        (click)="this.closeTimeSeries()"
+        class="closeBtn"
+        matTooltip="Close Time Series Chart"
+      >
+        <mat-icon>close</mat-icon>
+      </button>
       <mat-dialog-content>
         <ngx-charts-line-chart
           *ngIf="DataAvailable()"

--- a/src/app/timeseries-menu.component.html
+++ b/src/app/timeseries-menu.component.html
@@ -49,9 +49,9 @@
           </ng-template>
           <ng-template #seriesTooltipTemplate let-model="model">
             <p>
-              <u><b>Date:</b> {{ chartToolTipDate(model | json) }}</u>
+              <u><b>Date:</b> {{ getTTDate(model | json) }}</u>
             </p>
-            <div *ngFor="let data of getToolTipData(model | json)">
+            <div *ngFor="let data of getSeriesToolTipData(model | json)">
               <p>
                 <b>{{ yValTitle() }}:</b> {{ data.value }}<br />
                 <b>Layer: </b> {{ this._model.settings.levelCheck(data.layer) }}

--- a/src/app/timeseries-menu.component.html
+++ b/src/app/timeseries-menu.component.html
@@ -3,6 +3,7 @@
     <div class="main">
       <h2 mat-dialog-title>Time Series</h2>
       <button
+        mat-raised-button
         id="graph_button"
         [useExistingCss]="true"
         printSectionId="print-section"
@@ -10,6 +11,7 @@
       >
         Save Graph
       </button>
+      <button mat-icon-button (click)="this.closeTimeSeries()" class="closeBtn" matTooltip="Close Time Series Chart"><mat-icon>close</mat-icon></button>
       <mat-dialog-content>
         <ngx-charts-line-chart
           *ngIf="DataAvailable()"
@@ -24,9 +26,31 @@
           [showXAxisLabel]="showXAxisLabel"
           [showYAxisLabel]="showYAxisLabel"
           [xAxisLabel]="xAxisLabel"
-          [yAxisLabel]="yAxisLabel"
+          [yAxisLabel]="yValTitle()"
           [autoScale]="autoScale"
         >
+          <ng-template #tooltipTemplate let-model="model">
+            <div *ngFor="let data of getToolTipData(model | json)">
+              <p>
+                <u><b>Date:</b> {{ data.date }}</u>
+              </p>
+              <p>
+                <b>{{ yValTitle() }}:</b> {{ data.value }}<br />
+                <b>Layer: </b> {{ this._model.settings.levelCheck(data.layer) }}
+              </p>
+            </div>
+          </ng-template>
+          <ng-template #seriesTooltipTemplate let-model="model">
+            <p>
+              <u><b>Date:</b> {{ chartToolTipDate(model | json) }}</u>
+            </p>
+            <div *ngFor="let data of getToolTipData(model | json)">
+              <p>
+                <b>{{ yValTitle() }}:</b> {{ data.value }}<br />
+                <b>Layer: </b> {{ this._model.settings.levelCheck(data.layer) }}
+              </p>
+            </div>
+          </ng-template>
         </ngx-charts-line-chart>
 
         <br />
@@ -47,7 +71,7 @@
         [checked]="IsSelected(level)"
         (click)="ToggleTimeseries(level)"
       >
-        {{ level.Name }}
+        {{ this._model.settings.levelCheck(level.Name) }}
       </mat-checkbox>
     </mat-dialog-actions>
   </div>

--- a/src/app/timeseries-menu.component.ts
+++ b/src/app/timeseries-menu.component.ts
@@ -1,11 +1,11 @@
 import { Component, Inject, ViewChild } from "@angular/core";
 import { MAT_DIALOG_DATA } from "@angular/material";
 
+import { MatDialogRef } from "@angular/material/dialog";
 import { Helpers } from "./helpers";
 import { Model } from "./model";
 import { Settings } from "./settings";
 import { TimeseriesData } from "./timeseriesData";
-import {MatDialogRef} from '@angular/material/dialog';
 /**
  * Created by dafre on 5/14/2017.
  */
@@ -88,8 +88,10 @@ export class TimeseriesMenuComponent {
     return this.levelsLoaded === this.multi.length && this.levelsLoaded > 0;
   }
 
-  public constructor(private dialogRef: MatDialogRef<TimeseriesMenuComponent>,
-                     @Inject(MAT_DIALOG_DATA) public data: any) {
+  public constructor(
+    private dialogRef: MatDialogRef<TimeseriesMenuComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: any
+  ) {
     this._model = data;
     this.levelsLoaded = 1;
     this.multi = new Array<any>();
@@ -168,7 +170,6 @@ export class TimeseriesMenuComponent {
       return yTitle + " (" + this._model.settings.DataUnits + ")";
     }
   }
-
 
   public IsSelected(level): boolean {
     const selected = false;

--- a/src/app/timeseries-menu.component.ts
+++ b/src/app/timeseries-menu.component.ts
@@ -62,7 +62,6 @@ export class TimeseriesMenuComponent {
   autoScale = true;
 
   private _model: Model;
-  private dateJson: any;
 
   public GetLevels() {
     return this._model.settings.Levels;
@@ -122,31 +121,34 @@ export class TimeseriesMenuComponent {
     }
   }
 
-  getToolTipData(jsonString) {
+  getSeriesToolTipData(jsonString) { // Get graph tool tip data for multiple levels
     this.toolTipData = [];
-    const jsonArr = jsonString.split("{"); // counter,, jsonArr.length = n + 1 where n is number of layers selected
-    for (let i = 1; i < jsonArr.length; i++) {
-      const v = jsonArr[i].split('value": ');
-      const d = jsonArr[i].split('name": ');
-      const series = jsonArr[i].split('series": ');
-      const l = series[1].split('"'); // layer
-      v[1] = v[1].substr(0, 4); // value
-      d[1] = d[1].substr(1, 7); // date
+    const jsonArr = JSON.parse(jsonString);
+    for (let i = 0; i < jsonArr.length; i++) {
       this.toolTipData.push({
-        date: d[1],
-        value: v[1],
-        layer: l[1]
+        date: jsonArr[i].name, // date
+        value: jsonArr[i].value.toFixed(4), // value
+        layer: jsonArr[i].series // layer
       });
     }
     return this.toolTipData;
   }
 
-  chartToolTipDate(jsonString) {
-    this.dateJson = jsonString;
-    let nameIndex = this.dateJson.indexOf("name");
-    nameIndex += 8;
-    return this.dateJson.substr(nameIndex, 7);
-  }
+  getToolTipData(jsonString) { // Get graph tool tip data for a single level
+    this.toolTipData = [];
+    const jsonArr = JSON.parse(jsonString);
+      this.toolTipData.push({
+        date: jsonArr.name, // date
+        value: jsonArr.value.toFixed(4), // value
+        layer: jsonArr.series // layer
+      });
+      return this.toolTipData;
+    }
+
+    getTTDate(jsonString) {
+      return JSON.parse(jsonString)[0].name; // return just date
+    }
+
 
   closeTimeSeries() {
     this.dialogRef.close();

--- a/src/app/timeseries-menu.component.ts
+++ b/src/app/timeseries-menu.component.ts
@@ -87,10 +87,21 @@ export class TimeseriesMenuComponent {
     return this.levelsLoaded === this.multi.length && this.levelsLoaded > 0;
   }
 
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> prettier/tslint
   public constructor(
     private dialogRef: MatDialogRef<TimeseriesMenuComponent>,
     @Inject(MAT_DIALOG_DATA) public data: any
   ) {
+<<<<<<< HEAD
+=======
+  public constructor(private dialogRef: MatDialogRef<TimeseriesMenuComponent>,
+                     @Inject(MAT_DIALOG_DATA) public data: any) {
+>>>>>>> rebase
+=======
+>>>>>>> prettier/tslint
     this._model = data;
     this.levelsLoaded = 1;
     this.multi = new Array<any>();
@@ -121,7 +132,11 @@ export class TimeseriesMenuComponent {
     }
   }
 
-  getSeriesToolTipData(jsonString) { // Get graph tool tip data for multiple levels
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+  getSeriesToolTipData(jsonString) {
+    // Get graph tool tip data for multiple levels
     this.toolTipData = [];
     const jsonArr = JSON.parse(jsonString);
     for (let i = 0; i < jsonArr.length; i++) {
@@ -129,26 +144,82 @@ export class TimeseriesMenuComponent {
         date: jsonArr[i].name, // date
         value: jsonArr[i].value.toFixed(4), // value
         layer: jsonArr[i].series // layer
+=======
+  getToolTipData(jsonString) {
+=======
+  getSeriesToolTipData(jsonString) { // Get graph tool tip data for multiple levels
+>>>>>>> rebase 2
+=======
+  getSeriesToolTipData(jsonString) {
+    // Get graph tool tip data for multiple levels
+>>>>>>> rebase 3
+    this.toolTipData = [];
+    const jsonArr = JSON.parse(jsonString);
+    for (let i = 0; i < jsonArr.length; i++) {
+      this.toolTipData.push({
+<<<<<<< HEAD
+        date: d[1],
+        value: v[1],
+        layer: l[1]
+>>>>>>> rebase
+=======
+        date: jsonArr[i].name, // date
+        value: jsonArr[i].value.toFixed(4), // value
+        layer: jsonArr[i].series // layer
+>>>>>>> rebase 2
       });
     }
     return this.toolTipData;
   }
 
-  getToolTipData(jsonString) { // Get graph tool tip data for a single level
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+  getToolTipData(jsonString) {
+    // Get graph tool tip data for a single level
     this.toolTipData = [];
     const jsonArr = JSON.parse(jsonString);
-      this.toolTipData.push({
-        date: jsonArr.name, // date
-        value: jsonArr.value.toFixed(4), // value
-        layer: jsonArr.series // layer
-      });
-      return this.toolTipData;
-    }
+    this.toolTipData.push({
+      date: jsonArr.name, // date
+      value: jsonArr.value.toFixed(4), // value
+      layer: jsonArr.series // layer
+    });
+    return this.toolTipData;
+  }
 
-    getTTDate(jsonString) {
-      return JSON.parse(jsonString)[0].name; // return just date
-    }
+  getTTDate(jsonString) {
+    return JSON.parse(jsonString)[0].name; // return just date
+=======
+  chartToolTipDate(jsonString) {
+    this.dateJson = jsonString;
+    let nameIndex = this.dateJson.indexOf("name");
+    nameIndex += 8;
+    return this.dateJson.substr(nameIndex, 7);
+>>>>>>> rebase
+  }
+=======
+  getToolTipData(jsonString) { // Get graph tool tip data for a single level
+=======
+  getToolTipData(jsonString) {
+    // Get graph tool tip data for a single level
+>>>>>>> rebase 3
+    this.toolTipData = [];
+    const jsonArr = JSON.parse(jsonString);
+    this.toolTipData.push({
+      date: jsonArr.name, // date
+      value: jsonArr.value.toFixed(4), // value
+      layer: jsonArr.series // layer
+    });
+    return this.toolTipData;
+  }
 
+<<<<<<< HEAD
+>>>>>>> rebase 2
+=======
+  getTTDate(jsonString) {
+    return JSON.parse(jsonString)[0].name; // return just date
+  }
+>>>>>>> rebase 3
 
   closeTimeSeries() {
     this.dialogRef.close();
@@ -173,6 +244,13 @@ export class TimeseriesMenuComponent {
     }
   }
 
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+
+>>>>>>> rebase
+=======
+>>>>>>> prettier/tslint
   public IsSelected(level): boolean {
     const selected = false;
     for (let counter = 0; counter < this.multi.length; counter++) {

--- a/src/app/timeseries-menu.component.ts
+++ b/src/app/timeseries-menu.component.ts
@@ -5,6 +5,7 @@ import { Helpers } from "./helpers";
 import { Model } from "./model";
 import { Settings } from "./settings";
 import { TimeseriesData } from "./timeseriesData";
+import {MatDialogRef} from '@angular/material/dialog';
 /**
  * Created by dafre on 5/14/2017.
  */
@@ -23,6 +24,11 @@ export class TimeseriesMenuComponent {
   multi: TimeseriesData[] = new Array<any>();
   view: any[];
   levelsLoaded = 0;
+  toolTipData: Array<{
+    date: string;
+    value: string;
+    layer: string;
+  }>;
 
   // options
   showXAxis = true;
@@ -37,8 +43,8 @@ export class TimeseriesMenuComponent {
 
   colorScheme = {
     domain: [
-      "#a6cee3",
       "#1f78b4",
+      "#a6cee3",
       "#b2df8a",
       "#33a02c",
       "#fb9a99",
@@ -56,6 +62,7 @@ export class TimeseriesMenuComponent {
   autoScale = true;
 
   private _model: Model;
+  private dateJson: any;
 
   public GetLevels() {
     return this._model.settings.Levels;
@@ -78,12 +85,11 @@ export class TimeseriesMenuComponent {
   }
 
   public DataAvailable() {
-    return this.levelsLoaded === this.multi.length && this.levelsLoaded > 0
-      ? true
-      : false;
+    return this.levelsLoaded === this.multi.length && this.levelsLoaded > 0;
   }
 
-  public constructor(@Inject(MAT_DIALOG_DATA) public data: any) {
+  public constructor(private dialogRef: MatDialogRef<TimeseriesMenuComponent>,
+                     @Inject(MAT_DIALOG_DATA) public data: any) {
     this._model = data;
     this.levelsLoaded = 1;
     this.multi = new Array<any>();
@@ -113,6 +119,56 @@ export class TimeseriesMenuComponent {
       }
     }
   }
+
+  getToolTipData(jsonString) {
+    this.toolTipData = [];
+    const jsonArr = jsonString.split("{"); // counter,, jsonArr.length = n + 1 where n is number of layers selected
+    for (let i = 1; i < jsonArr.length; i++) {
+      const v = jsonArr[i].split('value": ');
+      const d = jsonArr[i].split('name": ');
+      const series = jsonArr[i].split('series": ');
+      const l = series[1].split('"'); // layer
+      v[1] = v[1].substr(0, 4); // value
+      d[1] = d[1].substr(1, 7); // date
+      this.toolTipData.push({
+        date: d[1],
+        value: v[1],
+        layer: l[1]
+      });
+    }
+    return this.toolTipData;
+  }
+
+  chartToolTipDate(jsonString) {
+    this.dateJson = jsonString;
+    let nameIndex = this.dateJson.indexOf("name");
+    nameIndex += 8;
+    return this.dateJson.substr(nameIndex, 7);
+  }
+
+  closeTimeSeries() {
+    this.dialogRef.close();
+  }
+
+  yValTitle() {
+    if (!this.DataAvailable()) {
+      return "Value";
+    }
+    const yTitle = this._model.settings.GenerateSimpleTitle(
+      this._model.settings.FullName
+    );
+    if (yTitle.search("Temperature") >= 0) {
+      return yTitle.concat(" (\xB0C)");
+    } else if (
+      yTitle === "Volumetric Soil Moisture" ||
+      yTitle === "ice thickness"
+    ) {
+      return yTitle;
+    } else {
+      return yTitle + " (" + this._model.settings.DataUnits + ")";
+    }
+  }
+
 
   public IsSelected(level): boolean {
     const selected = false;

--- a/src/app/view.component.css
+++ b/src/app/view.component.css
@@ -187,6 +187,6 @@ button:focus {
   margin: 0px;
 }
 
-closebutton:focus {
+.closebutton:focus {
   background: none;
 }

--- a/src/app/view.component.html
+++ b/src/app/view.component.html
@@ -58,7 +58,7 @@
                 [value]="level.Name"
                 (change)="ChangeLevel(level.Level_ID)"
               >
-                {{ level.Name }}
+                {{ this._model.settings.levelCheck(level.Name) }}
               </mat-radio-button>
             </mat-radio-group>
           </div>

--- a/src/app/view.component.ts
+++ b/src/app/view.component.ts
@@ -345,17 +345,15 @@ export class ViewComponent implements OnInit, AfterViewInit {
   }
 
   public GetLayerDateLabel(): string {
+
     if (this._model != null) {
       if (this._model.settings != null) {
         if (
           this._model.settings.LevelName != null &&
           this._model.settings.CurrDate != null
         ) {
-          return (
-            this._model.settings.LevelName +
-            " | " +
-            this._model.settings.CurrDate.substring(0, 7)
-          );
+          const level = this._model.settings.levelCheck(this._model.settings.LevelName);
+          return (`${level} | ${this._model.settings.CurrDate.substring(0, 7)}`);
         }
       }
     }

--- a/src/app/view.component.ts
+++ b/src/app/view.component.ts
@@ -351,10 +351,21 @@ export class ViewComponent implements OnInit, AfterViewInit {
           this._model.settings.LevelName != null &&
           this._model.settings.CurrDate != null
         ) {
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> prettier/tslint
           const level = this._model.settings.levelCheck(
             this._model.settings.LevelName
           );
           return `${level} | ${this._model.settings.CurrDate.substring(0, 7)}`;
+<<<<<<< HEAD
+=======
+          const level = this._model.settings.levelCheck(this._model.settings.LevelName);
+          return (`${level} | ${this._model.settings.CurrDate.substring(0, 7)}`);
+>>>>>>> rebase
+=======
+>>>>>>> prettier/tslint
         }
       }
     }

--- a/src/app/view.component.ts
+++ b/src/app/view.component.ts
@@ -345,15 +345,16 @@ export class ViewComponent implements OnInit, AfterViewInit {
   }
 
   public GetLayerDateLabel(): string {
-
     if (this._model != null) {
       if (this._model.settings != null) {
         if (
           this._model.settings.LevelName != null &&
           this._model.settings.CurrDate != null
         ) {
-          const level = this._model.settings.levelCheck(this._model.settings.LevelName);
-          return (`${level} | ${this._model.settings.CurrDate.substring(0, 7)}`);
+          const level = this._model.settings.levelCheck(
+            this._model.settings.LevelName
+          );
+          return `${level} | ${this._model.settings.CurrDate.substring(0, 7)}`;
         }
       }
     }


### PR DESCRIPTION
Last part of splitting LogoAndTimeSeries3 branch.

Features include:
* Y-Axis title
* Save Graph button is now a material button
* Initial graph line color is darker
* Exit graph button
* Swap "Default" with "Single Level" (Note: Not able to swap easily with the "Legend" in the time series chart due to limitations with ngx-charts, so that is the only place where default would still be found)
* Cleaner time series chart tool tips