### PR TITLE
ID - Fixing checkbox bug

### DIFF
--- a/src/app/timeseries-menu.component.html
+++ b/src/app/timeseries-menu.component.html
@@ -153,8 +153,8 @@
     <mat-dialog-actions>
       <mat-checkbox
         *ngFor="let level of GetLevels(); index as checkboxIndex"
-        [checked]="checkboxIndex == 0"
-        [disabled]="lonerLevelCheck() === checkboxIndex"
+        [checked]="isChecked(checkboxIndex)"
+        [disabled]="lonerLevelCheck(checkboxIndex)"
         (change)="ToggleTimeseries(level)"
       >
         {{ this._model.settings.levelCheck(level.Name) }}

--- a/src/app/timeseries-menu.component.ts
+++ b/src/app/timeseries-menu.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, ViewChild } from "@angular/core";
+import { Component, Inject } from "@angular/core";
 import { MAT_DIALOG_DATA } from "@angular/material";
 import { MatDialog, MatDialogRef } from "@angular/material/dialog";
 import { MatMenuModule } from "@angular/material/menu";
@@ -132,12 +132,20 @@ export class TimeseriesMenuComponent {
     });
   }
 
-  // returns the index of the lone level that is currently selected
-  private lonerLevelCheck(): number {
-    if (this.levelsLoaded <= 1 && this.DataAvailable()) {
-      return this.multi[0].level_ID - 1;
+  // returns if a checkbox should be disabled for being the only one checked
+  private lonerLevelCheck(index) {
+    return this.multi.length === 1 && this.multi[0].level_ID - 1 === index;
+  }
+
+  // returns if the checkbox should be checked or not
+  private isChecked(index) {
+    let flag = false;
+    for (let i = 0; i < this.multi.length; i++) {
+      if (this.multi[i].level_ID - 1 === index) {
+        flag = true;
+      }
     }
-    return -1;
+    return flag;
   }
 
   public GetLevels() {


### PR DESCRIPTION
Fixes a bug where selecting a different pressure level and then opening the time series menu did not correctly reflect the selected pressure level in the checkbox area below the time series graph.