### PR TITLE
ID - Fixes legend and legend slider reload bug

### DIFF
--- a/src/app/settings.ts
+++ b/src/app/settings.ts
@@ -122,10 +122,10 @@ export class Settings {
 
   // display related settings
   currColormapName =
-    "Color Brewer 2.0|Diverging|Zero Centered|11-class Spectral Inverse";
+    "Color Brewer 2.0|Diverging|Non Centered|11-class Spectral Inverse";
   smoothGridBoxValues = true;
   globeView: GlobeViewType = GlobeViewType.Ortho;
-  functionForColorMap = "customColorMapWithMidpoint";
+  functionForColorMap = "customColorMap";
   CoastsType = "./assets/ne_110m_coastline.json";
   LakesType = "Low";
   RiversType = "Low";

--- a/src/app/view.component.ts
+++ b/src/app/view.component.ts
@@ -205,6 +205,14 @@ export class ViewComponent implements OnInit, AfterViewInit {
     vertical: true
   };
 
+  // Waits for the dataset to be updated to correctly
+  // update the legend slider with up to date data
+  private waitForDataLoad() {
+    setTimeout(() => {
+      this.updateSlider();
+    }, 1000); // TODO: Remove setTimeout and make the update more efficient
+  }
+
   // update globe and legend based on slider
   private setGlobeAndLegend() {
     // if the data was converted to scientific notation, convert values back to correctly color the values on the globe
@@ -790,6 +798,8 @@ export class ViewComponent implements OnInit, AfterViewInit {
       this._model.settings.CurrDate,
       this._model.settings.Level_ID
     );
+
+    this.waitForDataLoad();
   }
 
   ChangeYear() {
@@ -807,6 +817,8 @@ export class ViewComponent implements OnInit, AfterViewInit {
       this._model.settings.CurrDate,
       this._model.settings.Level_ID
     );
+
+    this.waitForDataLoad();
   }
 
   ChangeLevel(level_id: number) {
@@ -815,6 +827,8 @@ export class ViewComponent implements OnInit, AfterViewInit {
       this._model.settings.CurrDate,
       level_id
     );
+
+    this.waitForDataLoad();
   }
 
   OpenColorMapDialog() {


### PR DESCRIPTION
Fixes a bug where the legend and legend slider would not update after changing the level or date.

I also changed the default color map because having the non centered color map shows off the difference in values better on the earth for lower level datasets where all values in the dataset are either greater than 0 or less than 0.