### PR TITLE
ID - Adding interactive tutorial

### DIFF
--- a/src/app/about4dvd.component.css
+++ b/src/app/about4dvd.component.css
@@ -1,0 +1,6 @@
+.buttonColor,
+.buttonColor:focus,
+.buttonColor:active,
+:after {
+  background-color: white;
+}

--- a/src/app/about4dvd.component.html
+++ b/src/app/about4dvd.component.html
@@ -2,18 +2,13 @@
   <h2 mat-dialog-title>About 4DVD</h2>
   <mat-dialog-content>
     <div style="text-align: center; margin-bottom: 15px">
-      <h5>Basic Functions of 4DVD Tutorial</h5>
-      <iframe
-        width="560"
-        height="315"
-        src="https://www.youtube.com/embed/VFvWAFo4Lp8"
-        frameborder="0"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-      ></iframe>
-      <p>PDF Version:</p>
-      <button mat-raised-button (click)="this.getPDF()">
-        Basic Functions of 4DVD Tutorial
+      <h5><u>New to 4DVD?</u></h5>
+      <button
+        class="buttonColor"
+        mat-raised-button
+        (click)="openTutorialDialog()"
+      >
+        Check out the 4DVD tutorials here!
       </button>
     </div>
     <mat-divider></mat-divider>

--- a/src/app/about4dvd.component.ts
+++ b/src/app/about4dvd.component.ts
@@ -1,33 +1,17 @@
-import { HttpClient } from "@angular/common/http";
 import { Component, OnInit } from "@angular/core";
-import { DomSanitizer } from "@angular/platform-browser";
+import { MatDialog } from "@angular/material/dialog";
+import { TutorialMenuComponent } from "./tutorial-menu/tutorial-menu.component";
 
 @Component({
   templateUrl: "./about4dvd.component.html",
   styleUrls: ["./about4dvd.component.css"]
 })
 export class About4dvdComponent implements OnInit {
-  safeURL;
-  videoURL = "https://www.youtube.com/watch?v=VFvWAFo4Lp8&t=1s";
-  constructor(private _sanitizer: DomSanitizer, private http: HttpClient) {
-    this.safeURL = this._sanitizer.bypassSecurityTrustResourceUrl(
-      this.videoURL
-    );
-  }
+  constructor(private dialog: MatDialog) {}
 
   ngOnInit() {}
 
-  // TODO: This is a temporary location for the tutorials.
-  //  When the interactive tutorial gets made, these tutorials will be offered alongside it and permanently moved there.
-  // gets the PDF version of the Basic Functions of 4DVD Tutorial
-  private async getPDF() {
-    try {
-      const res = await this.http
-        .get(`/assets/BasicFunctions4DVDTutorial.pdf`, { responseType: "blob" })
-        .toPromise();
-      window.open(window.URL.createObjectURL(res));
-    } catch (e) {
-      console.log(e);
-    }
+  private openTutorialDialog() {
+    const dialogRef = this.dialog.open(TutorialMenuComponent);
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,7 +20,10 @@ import {
   MatTabsModule,
   MatTooltipModule
 } from "@angular/material";
+import { MatGridListModule } from "@angular/material/grid-list";
 import { MatMenuModule } from "@angular/material/menu";
+import { MatSnackBarModule } from "@angular/material/snack-bar";
+import { MatStepperModule } from "@angular/material/stepper";
 import { MatTreeModule } from "@angular/material/tree";
 import { BrowserModule } from "@angular/platform-browser";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
@@ -43,6 +46,7 @@ import { SeasonalChartComponent } from "./time-series-menus/seasonal-chart.compo
 import { SeasonalTimeSeriesGraphComponent } from "./time-series-menus/seasonal-time-series-graph.component";
 import { TimeSeriesStatisticsComponent } from "./time-series-statistics.component";
 import { TimeseriesMenuComponent } from "./timeseries-menu.component";
+import { TutorialMenuComponent } from './tutorial-menu/tutorial-menu.component';
 import { ViewComponent } from "./view.component";
 @NgModule({
   declarations: [
@@ -58,7 +62,8 @@ import { ViewComponent } from "./view.component";
     SeasonalChartComponent,
     ClimatologyGraphComponent,
     SeasonalTimeSeriesGraphComponent,
-    HistogramComponent
+    HistogramComponent,
+    TutorialMenuComponent
   ],
   imports: [
     BrowserAnimationsModule,
@@ -92,7 +97,10 @@ import { ViewComponent } from "./view.component";
     NgxPrintModule,
     RouterModule,
     AppRoutingModule,
-    HttpClientModule
+    HttpClientModule,
+    MatSnackBarModule,
+    MatStepperModule,
+    MatGridListModule
   ],
   providers: [
     GetJson,
@@ -111,7 +119,8 @@ import { ViewComponent } from "./view.component";
     SeasonalChartComponent,
     ClimatologyGraphComponent,
     SeasonalTimeSeriesGraphComponent,
-    HistogramComponent
+    HistogramComponent,
+    TutorialMenuComponent
   ]
 })
 export class AppModule {}

--- a/src/app/tutorial-menu/tutorial-menu.component.css
+++ b/src/app/tutorial-menu/tutorial-menu.component.css
@@ -1,0 +1,79 @@
+::ng-deep .mat-step-header .mat-step-icon-selected {
+  background-color: #2196f3;
+}
+
+::ng-deep div.mat-step-icon-state-edit.mat-step-icon {
+  background-color: #2196f3;
+}
+
+#ClimateTitle {
+  font-size: 15px;
+  color: black;
+  font-weight: bold;
+  cursor: pointer;
+}
+.txt-center, .tooltip-demo {
+  text-align: center;
+}
+
+.bullet-point {
+  align-content: center;
+  height: 24px;
+  width: 24px;
+}
+
+::ng-deep .mat-checkbox-label {
+  color: black;
+}
+
+.demo-grid-tile {
+  background-color: lightgrey
+}
+
+.desc-grid-tile {
+  width: 100%;
+  text-align: left;
+}
+
+.circle-icon {
+  font-size: 10px;
+}
+
+.logo {
+  height: 45px;
+  width: 45px;
+  margin-top: 5px;
+  margin-left: 5px;
+  cursor: pointer;
+}
+
+.title-demo {
+  position: static !important;
+}
+
+.top-buffer {
+  margin-top: 20px;
+}
+
+.bottom-buffer {
+  margin-bottom: 20px;
+}
+
+.check-buffer {
+  margin-right: 5px;
+}
+
+.btn-background {
+  background-color: #FFFFFF;
+}
+
+.tooltip-demo {
+  font-size: 12px;
+}
+
+.buttonColor,
+.buttonColor:focus,
+.buttonColor:active,
+:after {
+  background-color: white;
+}

--- a/src/app/tutorial-menu/tutorial-menu.component.html
+++ b/src/app/tutorial-menu/tutorial-menu.component.html
@@ -1,0 +1,365 @@
+<div>
+<mat-horizontal-stepper>
+  <!-- Changes the default stepper icon -->
+  <ng-template matStepperIcon="edit">
+    <mat-icon>done</mat-icon>
+  </ng-template>
+
+  <mat-step>
+    <ng-template matStepLabel>Welcome!</ng-template>
+    <div>
+      <h3>Welcome to 4DVD!</h3>
+      <h5><u>Brief Description</u></h5>
+      <div class="bottom-buffer">
+        <p >
+          4-Dimensional Visual Delivery of Big Climate Data, or 4DVD, is a digital
+          technology that can quickly and easily visualize and deliver historical climate
+          data. The technology is a software and has a friendly website interface. The
+          4DVD software can be applied to visualize and deliver any kind of space-time
+          data, ranging from air temperature to precipitation to wind speeds to even
+          humidity. Because of its friendly interface and fast speed, 4DVD can deliver
+          historical climate data to the general public, school students, and seniors, in
+          addition to scientists.
+        </p>
+      </div>
+      <mat-divider></mat-divider>
+          <div class="txt-center">
+          <h5>
+            <u>Prefer another style of tutorial?</u><br/>
+          </h5>
+            <iframe
+              width="280"
+              height="158"
+              src="https://www.youtube.com/embed/VFvWAFo4Lp8"
+              frameborder="0"
+              allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowfullscreen
+            ></iframe>
+            <p></p>
+            <button mat-raised-button (click)="this.getPDF()">
+              Basic Functions of 4DVD Tutorial PDF
+            </button></div>
+    </div>
+    <div>
+      <button class="buttonColor" mat-button matStepperNext>Next</button>
+    </div>
+  </mat-step>
+  <mat-step>
+    <ng-template matStepLabel>Top Row</ng-template>
+    <div>
+      <h3>Top Row</h3>
+      <p>
+        "Top Row" refers to the blue bar at the top of the 4DVD website.
+      </p>
+      <mat-divider></mat-divider>
+      <mat-grid-list cols="4" rowHeight="4:1" gutterSize="15px" class="top-buffer">
+        <mat-grid-tile>
+          <div class="desc-grid-tile">
+          <p>Click the 4DVD Logo to refresh the page</p>
+          </div>
+        </mat-grid-tile>
+        <mat-grid-tile class="demo-grid-tile">
+          <img
+            src="/assets/4DVDLogoV1.png"
+            alt="4DVD Logo Demo Button"
+            class="logo"
+            matTooltip="Demo Button"
+            matTooltipPosition="right"
+          />
+        </mat-grid-tile>
+        <mat-grid-tile>
+          <p>Click Top Datasets to view our top picked datasets</p>
+        </mat-grid-tile>
+        <mat-grid-tile class="demo-grid-tile">
+          <button
+            mat-button
+            matTooltip="Demo Button"
+            matTooltipPosition="right"
+            class="btn-background"
+          >
+            Top Datasets
+          </button>
+        </mat-grid-tile>
+        <mat-grid-tile>
+          <p>Click Datasets to open an advanced menu to view all the datasets 4DVD has to offer</p>
+        </mat-grid-tile>
+        <mat-grid-tile class="demo-grid-tile">
+          <button
+            mat-button
+            matTooltip="Demo Button"
+            matTooltipPosition="right"
+            class="btn-background"
+          >
+            Datasets
+          </button>
+        </mat-grid-tile>
+        <mat-grid-tile>
+          <p>Click Download Data to download a csv of the global data at the current date and level</p>
+        </mat-grid-tile>
+        <mat-grid-tile class="demo-grid-tile">
+          <button
+            mat-button
+            matTooltip="Demo Button"
+            matTooltipPosition="right"
+            class="btn-background"
+          >
+            Download Data
+          </button>
+        </mat-grid-tile>
+        <mat-grid-tile >
+          <div class="desc-grid-tile">
+            <p>Click About for more info on 4DVD</p>
+          </div>
+
+        </mat-grid-tile>
+        <mat-grid-tile class="demo-grid-tile">
+          <button
+            mat-button
+            matTooltip="Demo Button"
+            matTooltipPosition="right"
+            class="btn-background"
+          >
+            <mat-icon>info</mat-icon> About
+          </button>
+        </mat-grid-tile>
+      </mat-grid-list>
+    </div>
+    <div>
+      <button class="buttonColor" mat-button matStepperPrevious>Back</button>
+      <button class="buttonColor" mat-button matStepperNext>Next</button>
+    </div>
+  </mat-step>
+  <mat-step>
+    <ng-template matStepLabel>Main View</ng-template>
+    <div>
+      <h3>Main View</h3>
+      <p>
+        "Main View" refers to everything UNDER the top row.
+      </p>
+      <mat-divider></mat-divider>
+      <mat-grid-list cols="4" rowHeight="4:1" gutterSize="15px" class="top-buffer">
+        <mat-grid-tile>
+          <div class="desc-grid-tile">
+            <p>Click the Title to open the dataset menu. This is an alternative to the dataset button on the top row.</p>
+          </div>
+        </mat-grid-tile>
+        <mat-grid-tile class="demo-grid-tile">
+          <div id="ClimateTitle" class="title-demo" matTooltip="Demo Title">
+           Dataset Type | Data Collection Type
+          </div>
+        </mat-grid-tile>
+        <mat-grid-tile>
+          <div class="desc-grid-tile">
+            <p>Click the Hamburger to view more settings in a conventional menu.</p>
+          </div>
+        </mat-grid-tile>
+        <mat-grid-tile class="demo-grid-tile">
+          <button mat-button matTooltip="Demo Button" class="openLegendSlider"><mat-icon>menu</mat-icon></button>
+        </mat-grid-tile>
+        <mat-grid-tile>
+          <div class="desc-grid-tile">
+            <p>Click the Legend to open the Color Map Menu (shown later in the tutorial).</p>
+          </div>
+        </mat-grid-tile>
+        <mat-grid-tile class="demo-grid-tile">
+          <p>
+            *Located underneath the About button*
+          </p>
+        </mat-grid-tile>
+        <mat-grid-tile>
+          <div class="desc-grid-tile">
+            <p>Click the Arrow button above the Legend to show the Legend Slider.</p>
+          </div>
+        </mat-grid-tile>
+        <mat-grid-tile class="demo-grid-tile">
+          <button
+            mat-button
+            matTooltip="Demo Button"
+            class="openLegendSlider"
+          >
+            <mat-icon>keyboard_arrow_left</mat-icon>
+          </button>
+        </mat-grid-tile>
+        <mat-grid-tile>
+          <div class="desc-grid-tile">
+            <p>Click the Level's value on the bottom right to change the current Level.</p>
+          </div>
+        </mat-grid-tile>
+        <mat-grid-tile class="demo-grid-tile">
+          <span class="levelLabel" matTooltip="Demo Button">
+            Level
+          </span>
+          <span matTooltip="This is to change the date!">
+            | date
+          </span>
+        </mat-grid-tile>
+        <mat-grid-tile>
+          <div class="desc-grid-tile">
+            <p>Click the Date value on the bottom right to change the current Date.</p>
+          </div>
+        </mat-grid-tile>
+        <mat-grid-tile class="demo-grid-tile">
+          <span matTooltip="This is to change the level!">
+            level |
+          </span>
+          <span class="dateLabel" matTooltip="Demo Button">
+            Date
+          </span>
+        </mat-grid-tile>
+      </mat-grid-list>
+    </div>
+    <div>
+      <button class="buttonColor" mat-button matStepperPrevious>Back</button>
+      <button class="buttonColor" mat-button matStepperNext>Next</button>
+    </div>
+  </mat-step>
+  <mat-step>
+    <ng-template matStepLabel>Globe View</ng-template>
+    <div>
+      <h3>Globe View</h3>
+      <p>"Globe View" refers to just the globe/map of the earth.</p>
+      <mat-divider></mat-divider>
+      <div class="top-buffer">
+        <mat-list>
+          <mat-list-item>
+            <span class="bullet-point">
+              <mat-icon class="circle-icon">circle</mat-icon>
+            </span>
+            <span>
+              Click anywhere on the globe for the "Time Series Box" to pop up in the bottom left, showing the lat/lon and data value of the place on the globe you clicked at. You will also notice a button to open the Time Series Menu (explained later in the tutorial).
+            </span>
+          </mat-list-item>
+          <mat-list-item>
+            <span class="bullet-point">
+            <mat-icon class="circle-icon">circle</mat-icon>
+            </span>
+            <span>
+              Drag on the globe to rotate the globe.
+            </span>
+          </mat-list-item>
+          <mat-list-item>
+            <span class="bullet-point">
+              <mat-icon class="circle-icon">circle</mat-icon>
+            </span>
+            <span>
+              Scroll to zoom in and out of the globe.
+            </span>
+          </mat-list-item>
+          <mat-list-item>
+            <span class="bullet-point">
+              <mat-icon class="circle-icon">circle</mat-icon>
+            </span>
+            <span>
+              You can change the globe to be a 2D map if you click the hamburger -> paint brush -> scroll down to "Globe View"
+            </span>
+          </mat-list-item>
+        </mat-list>
+      </div>
+    </div>
+    <div>
+      <button class="buttonColor" mat-button matStepperPrevious>Back</button>
+      <button class="buttonColor" mat-button matStepperNext>Next</button>
+    </div>
+  </mat-step>
+  <mat-step>
+    <ng-template matStepLabel>Time Series Menu</ng-template>
+    <div>
+      <h3>Time Series Menu</h3>
+      <p>The "Time Series Menu" also features more advanced graphs and charts (climatology, statistics summary, linear trend, seasonal time series, mean and standard deviation) if you click the hamburger in the top left of the Time Series Menu!</p>
+      <mat-divider></mat-divider>
+      <div>
+        <mat-grid-list cols="4" rowHeight="3:1" gutterSize="15px" class="top-buffer">
+          <mat-grid-tile>
+            <div class="desc-grid-tile">
+              <p>Located inside the "Time Series Box", click the "Time Series" button to access the Time Series (TS) Menu.</p>
+            </div>
+          </mat-grid-tile>
+          <mat-grid-tile class="demo-grid-tile">
+            <div class="txt-center" matTooltip="Demo Button">
+              <button class="buttonColor" mat-raised-button>Time Series</button>
+            </div>
+          </mat-grid-tile>
+          <mat-grid-tile>
+            <div class="desc-grid-tile">
+              <p>Click the hamburger on the top left to save the graph, download a csv of the current viewed TS data, and/or view advanced graphs/charts.</p>
+            </div>
+          </mat-grid-tile>
+          <mat-grid-tile class="demo-grid-tile">
+            <div class="txt-center" matTooltip="Demo Button">
+              <button class="buttonColor" mat-raised-button><mat-icon>menu</mat-icon></button>
+            </div>
+          </mat-grid-tile>
+          <mat-grid-tile>
+            <div class="desc-grid-tile">
+              <p>Under the TS graph are checkboxes with the different levels you can view (Note: some datasets are single level)</p>
+            </div>
+          </mat-grid-tile>
+          <mat-grid-tile class="demo-grid-tile">
+            <div class="txt-center">
+              <mat-checkbox class="check-buffer" matTooltip="Demo Checkbox">Level 1</mat-checkbox>
+              <mat-checkbox class="check-buffer" matTooltip="Demo Checkbox">Level 2</mat-checkbox>
+              <mat-checkbox matTooltip="Demo Checkbox">Level 3</mat-checkbox>
+            </div>
+          </mat-grid-tile>
+          <mat-grid-tile>
+            <div class="desc-grid-tile">
+              <p>Hover over the TS graph to view tooltips that gives more accurate info.</p>
+            </div>
+          </mat-grid-tile>
+          <mat-grid-tile class="demo-grid-tile">
+            <div class="tooltip-demo" matTooltip="Demo TS Graph Tooltip">
+              <p><u><b>Date:</b> YYYY-MM</u></p>
+              <p><b>Data Type (Units):</b> Value</p>
+              <p><b>Level: </b> Value</p>
+            </div>
+          </mat-grid-tile>
+        </mat-grid-list>
+      </div>
+    </div>
+    <div>
+      <button class="buttonColor" mat-button matStepperPrevious>Back</button>
+      <button class="buttonColor" mat-button matStepperNext>Next</button>
+    </div>
+  </mat-step>
+  <mat-step>
+    <ng-template matStepLabel>Color Map Menu</ng-template>
+    <div>
+      <h3>Color Map Menu</h3>
+      <p>The "Color Map Menu" features a large collection of different ways to color the globe to suit your needs. The default color map is Color Brewer 2.0 | Diverging | Non Centered | 11-class Spectral Inverse.</p>
+      <mat-divider></mat-divider>
+    </div>
+    <div>
+      <mat-list>
+        <mat-list-item>
+            <span class="bullet-point">
+              <mat-icon class="circle-icon">circle</mat-icon>
+            </span>
+          <span>
+              Click on the Legend (under the About button on the Top Row) to open the Color Map Menu.
+            </span>
+        </mat-list-item>
+        <mat-list-item>
+            <span class="bullet-point">
+              <mat-icon class="circle-icon">circle</mat-icon>
+            </span>
+          <span>
+              The Color Map Menu is organized under 6 buttons. 4 Color Brewer 2.0 options, Matlab, and Other.
+            </span>
+        </mat-list-item>
+        <mat-list-item>
+            <span class="bullet-point">
+              <mat-icon class="circle-icon">circle</mat-icon>
+            </span>
+          <span>
+              You can also click the "Inverse Color Maps" slider at the top of the Color Map Menu to use the inverse versions of the color maps.
+            </span>
+        </mat-list-item>
+      </mat-list>
+    </div>
+    <div>
+      <button class="buttonColor" mat-button matStepperPrevious>Back</button>
+      <button class="buttonColor" mat-button (click)="closeTutorialMenu()">Finish</button>
+    </div>
+  </mat-step>
+</mat-horizontal-stepper>
+</div>

--- a/src/app/tutorial-menu/tutorial-menu.component.ts
+++ b/src/app/tutorial-menu/tutorial-menu.component.ts
@@ -1,0 +1,34 @@
+import {HttpClient} from "@angular/common/http";
+import { Component, OnInit } from '@angular/core';
+import {MatDialogRef} from "@angular/material/dialog";
+import {DomSanitizer} from "@angular/platform-browser";
+
+@Component({
+  selector: 'app-tutorial-menu',
+  templateUrl: './tutorial-menu.component.html',
+  styleUrls: ['./tutorial-menu.component.css']
+})
+export class TutorialMenuComponent implements OnInit {
+
+  constructor(private dialogRef: MatDialogRef<TutorialMenuComponent>, private _sanitizer: DomSanitizer, private http: HttpClient) { }
+
+  ngOnInit() {
+  }
+
+  private closeTutorialMenu() {
+    // closes the dialog box
+    this.dialogRef.close();
+  }
+
+  private async getPDF() {
+    try {
+      const res = await this.http
+        .get(`/assets/BasicFunctions4DVDTutorial.pdf`, { responseType: "blob" })
+        .toPromise();
+      window.open(window.URL.createObjectURL(res));
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+}

--- a/src/app/view.component.html
+++ b/src/app/view.component.html
@@ -407,7 +407,6 @@
     <button
       mat-button
       id="sideNavButton"
-      style=""
       [disableRipple]="true"
       class="example-fab buttonColor"
       (click)="sidenav.toggle()"

--- a/src/app/view.component.ts
+++ b/src/app/view.component.ts
@@ -3,6 +3,13 @@
  */
 
 import {
+  animate,
+  state,
+  style,
+  transition,
+  trigger
+} from "@angular/animations";
+import {
   AfterViewInit,
   Component,
   ElementRef,
@@ -11,9 +18,14 @@ import {
   ViewChild,
   ViewEncapsulation
 } from "@angular/core";
+import { MatDialog } from "@angular/material";
+import { MatSnackBar } from "@angular/material/snack-bar";
+import * as glMatrix from "gl-matrix";
 import { ClickOutsideModule } from "ng-click-outside";
 import { ChangeContext, Options } from "ng5-slider";
+import { ColorMapMenuComponent } from "./color-map-menu.component";
 import { Controller } from "./controller";
+import { DatasetTreeComponent } from "./dataset-tree.component";
 import { GetJson } from "./getJson";
 import { Gl } from "./gl";
 import { GlMatrix } from "./GlMatrix";
@@ -21,22 +33,12 @@ import { Helpers } from "./helpers";
 import { Model } from "./model";
 import { GlobeViewType, Settings } from "./settings";
 import { Shaders } from "./Shaders";
+import { TimeseriesMenuComponent } from "./timeseries-menu.component";
+import { TutorialMenuComponent } from "./tutorial-menu/tutorial-menu.component";
 import { UI } from "./ui";
 import { WebGLProgramEnh } from "./WebGLProgramEnh";
 import { WebGLTextureEnh } from "./WebGLTextureEnh";
 
-import {
-  animate,
-  state,
-  style,
-  transition,
-  trigger
-} from "@angular/animations";
-import { MatDialog } from "@angular/material";
-import * as glMatrix from "gl-matrix";
-import { ColorMapMenuComponent } from "./color-map-menu.component";
-import { DatasetTreeComponent } from "./dataset-tree.component";
-import { TimeseriesMenuComponent } from "./timeseries-menu.component";
 declare var jQuery: any;
 
 @Component({
@@ -833,7 +835,8 @@ export class ViewComponent implements OnInit, AfterViewInit {
 
   OpenColorMapDialog() {
     const dialogRef = this.dialog.open(ColorMapMenuComponent, {
-      data: this._model.colorMap
+      data: this._model.colorMap,
+      autoFocus: false
     });
     dialogRef.afterClosed().subscribe(colorMap => {
       if (colorMap != null) {
@@ -896,7 +899,11 @@ export class ViewComponent implements OnInit, AfterViewInit {
     }
   }
 
-  constructor(getJson: GetJson, public dialog: MatDialog) {
+  constructor(
+    getJson: GetJson,
+    public dialog: MatDialog,
+    private _snackBar: MatSnackBar
+  ) {
     this.inCanvas = false;
     this.inMenu = false;
     this._getJson = getJson;
@@ -927,6 +934,24 @@ export class ViewComponent implements OnInit, AfterViewInit {
     this.Shaders = new Shaders();
 
     // Start
+    this.openSnackBar();
+  }
+
+  private openSnackBar() {
+    const message = "New to 4DVD? Check out the tutorials!";
+    const action = "Go";
+
+    const snack = this._snackBar.open(message, action, {
+      duration: 1000 * 10 // show snackbar for 10 seconds
+    });
+
+    snack.onAction().subscribe(a => {
+      this.openTutorialDialog();
+    });
+  }
+
+  private openTutorialDialog() {
+    const dialogRef = this.dialog.open(TutorialMenuComponent);
   }
 
   webGLStart() {


### PR DESCRIPTION
This PR adds an angular material "snackbar" that shows up for the first 10 seconds on load to prompt new users to view the getting started tutorials. It also adds an "interactive" tutorial for users to learn the basics of 4DVD, giving users 3 options (interactive, pdf, video) to suit their preference.

This PR also moves the video/pdf tutorials out of the About menu and into the tutorial menu and replaces that with a link to open the tutorial menu in case the user needs to view the tutorial again.

The beta can be found here: https://4dvd.sdsu.edu/beta/WalkthroughTut/